### PR TITLE
Add missing preposition in account agreement

### DIFF
--- a/bbva-compass-account-agreement.html.erb
+++ b/bbva-compass-account-agreement.html.erb
@@ -42,8 +42,8 @@ effective_date: 25 October, 2016
 
 <p><strong>Whether you think this stuff is interesting (hello, like-minded person!) or don’t have time to even read this
 far (we understand), The important thing is that you have this information if and when you need it. You
-can access it anytime on this page. And if you’re curious, you can see any change we make in our public
-policy GitHub.</strong></p>
+can access it anytime on this page. And if you’re curious, you can see any change we make to our public
+policy on GitHub.</strong></p>
 
 <p><strong>If anything here raises a question for you, hit us up. We’re always game for a lively, plainspoken chat
 about the wonderful world of debits, credits, interest, and interchange.</p></strong>


### PR DESCRIPTION
I added the word `on` where it was missing.

I also changed `in` to `to`, just because it seems changes are made _to_ something, rather than _in_ something.

Definitely nothing important. Just stuff that jumped out at me.
